### PR TITLE
Use hamcrest with fixed type specs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,4 @@
 {deps, [
-  {hamcrest, ".*", {git, "https://github.com/hyperthunk/hamcrest-erlang.git",
-                    "8a90a12"}},
+  {hamcrest, ".*", {git, "https://github.com/hyperthunk/hamcrest-erlang.git", "908a24fda4a46776a5135db60ca071e3d783f9f6"}},
   {wsock, ".*", {git, "https://github.com/esl/wsock", "251e18b"}}
 ]}.


### PR DESCRIPTION
Uses new version of hamcrest, compatible with OTP 18.0.